### PR TITLE
fix: comment out unused imports

### DIFF
--- a/src/components/HomeScreen/Navbar/Navbar.test.tsx
+++ b/src/components/HomeScreen/Navbar/Navbar.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-import Navbar from "./Navbar";
-import { describe, test, expect } from "vitest";
+// import { render, screen } from "@testing-library/react";
+// import Navbar from "./Navbar";
+// import { describe, test, expect } from "vitest";
 
 // TODO: fix file
 // describe("<Navbar />", () => {


### PR DESCRIPTION
I commented out imports that railway logs complained about.